### PR TITLE
[어드민] 데이터베이스 접근 로직 테스트 정의

### DIFF
--- a/src/main/java/com/fastcampus/boardadmin/config/JpaConfig.java
+++ b/src/main/java/com/fastcampus/boardadmin/config/JpaConfig.java
@@ -1,0 +1,29 @@
+package com.fastcampus.boardadmin.config;
+
+
+import com.fastcampus.boardadmin.dto.security.BoardAdminPrincipal;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+
+
+    @Bean()
+    public AuditorAware<String> auditorAware() {
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getPrincipal)
+                .map(BoardAdminPrincipal.class::cast)
+                .map(BoardAdminPrincipal::getUsername);
+    }
+}

--- a/src/main/java/com/fastcampus/boardadmin/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcampus/boardadmin/repository/UserAccountRepository.java
@@ -1,0 +1,7 @@
+package com.fastcampus.boardadmin.repository;
+
+import com.fastcampus.boardadmin.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,10 @@
+-- 테스트 계정
+-- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
+insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by,
+                          modified_at, modified_by)
+values ('twonezero', '{noop}asdf1234', 'ADMIN', 'Twonezero', 'twonezero@mail.com', 'I am Twonezero.', now(), 'twonezero', now(), 'twonezero'),
+       ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'twonezero', now(), 'twonezero'),
+       ('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'twonezero', now(),
+        'twonezero'),
+       ('jim', '{noop}asdf1234', 'USER', 'Jim', 'jim@mail.com', 'I am Jim.', now(), 'twonezero', now(), 'twonezero')
+;

--- a/src/test/java/com/fastcampus/boardadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/boardadmin/repository/JpaRepositoryTest.java
@@ -1,0 +1,111 @@
+package com.fastcampus.boardadmin.repository;
+
+
+import com.fastcampus.boardadmin.domain.UserAccount;
+import com.fastcampus.boardadmin.domain.constant.RoleType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("JPA 연결 테스트")
+@Import({JpaRepositoryTest.TestJpaConfig.class})
+@DataJpaTest
+class JpaRepositoryTest {
+    private final UserAccountRepository userAccountRepository;
+
+
+    public JpaRepositoryTest(
+            @Autowired UserAccountRepository userAccountRepository
+    ) {
+        this.userAccountRepository = userAccountRepository;
+    }
+
+
+    @DisplayName("회원 정보 select 테스트")
+    @Test
+    void givenUserAccounts_whenSelecting_thenWorksFine() {
+        //Given
+
+        //When
+        List<UserAccount> userAccounts = userAccountRepository.findAll();
+
+        //Then
+        assertThat(userAccounts)
+                .isNotNull()
+                .hasSize(4);
+    }
+
+    @DisplayName("회원 정보 insert 테스트")
+    @Test
+    void givenUserAccount_whenInserting_thenWorksFine() {
+        //Given
+        long prevCount = userAccountRepository.count();
+        UserAccount userAccount = UserAccount.of("testId", "testpwd", Set.of(RoleType.DEVELOPER),"test@mail.com",null,null);
+
+
+        //When
+        userAccountRepository.save(userAccount);
+
+        //Then
+        assertThat(userAccountRepository.count()).isEqualTo(prevCount + 1);
+
+    }
+
+    @DisplayName("회원 정보 update 테스트")
+    @Test
+    void givenUserAccountInfoAndRoleType_whenUpdating_thenWorksFine() {
+        //Given
+
+        UserAccount userAccount = userAccountRepository.getReferenceById("twonezero");
+
+        userAccount.addRoleType(RoleType.DEVELOPER);
+        userAccount.addRoleTypes(List.of(RoleType.ADMIN, RoleType.USER, RoleType.USER));
+        userAccount.removeRoleType(RoleType.ADMIN);
+
+
+
+        //When
+        var updatedUser =userAccountRepository.save(userAccount);
+
+        //Then
+        assertThat(updatedUser)
+                .hasFieldOrPropertyWithValue("userId","twonezero")
+                .hasFieldOrPropertyWithValue("roleTypes",Set.of(RoleType.DEVELOPER, RoleType.USER));
+    }
+
+    @DisplayName("회원 정보 delete 테스트")
+    @Test
+    void givenUserAccount_whenDeleting_thenWorksFine() {
+        //Given
+        long prevCount = userAccountRepository.count();
+        var userAccount = userAccountRepository.getReferenceById("twonezero");
+
+        //When
+        userAccountRepository.delete(userAccount);
+
+        //Then
+        assertThat(userAccountRepository.count()).isEqualTo(prevCount - 1);
+    }
+
+
+    @EnableJpaAuditing
+    @TestConfiguration
+    static class TestJpaConfig {
+        @Bean
+        AuditorAware<String> auditorAware(){return () -> Optional.of("twonezero");}
+    }
+
+}
+


### PR DESCRIPTION
회원 데이터에 접근할 리포지토리 인터페이스와
jpa auditing 기능을 활성화시킬 `JpaConfig`,
각자 다른 권한을 가진 테스트용 회원 데이터,
crud 쿼리 생성을 확인할 jpa 테스트 작성

This closes #5 